### PR TITLE
add marketplace account financial resource

### DIFF
--- a/tapioca_iugu/resource_mapping.py
+++ b/tapioca_iugu/resource_mapping.py
@@ -236,6 +236,11 @@ RESOURCE_MAPPING = {
         'docs': 'https://iugu.com/referencias/api#atualização-de-dados-bancários',
         'methods': ['POST']
     },
+    'marketplace_account_financial': {
+        'resource': 'accounts/financial',
+        'docs': '',
+        'methods': ['GET']
+    },
     'withdraw_request_list': {
         'resource': 'withdraw_requests',
         'docs': 'https://iugu.com/referencias/api#listar-transferências',


### PR DESCRIPTION
I had to access information from the financial statement of a sub account of the marketplace, but through their dashboard there is no option to access previous months, I contacted them, they informed me this url, passing the user_token from the sub account, and parameters such as year, month, We will be able to access all the transactions of that period.

Unfortunately it does not appear in their documentation.

Sample of usage:

curl -X GET https://api.iugu.com/v1/accounts/financial -u {subaccount_user_token}: -d year=2017 -d month=01